### PR TITLE
Update readme-qt.rst

### DIFF
--- a/doc/readme-qt.rst
+++ b/doc/readme-qt.rst
@@ -4,17 +4,16 @@ Bitcoin-qt: Qt4 GUI for Bitcoin
 Build instructions
 ===================
 
-Debian
--------
+Debian/Ubuntu
+-------------
 
-First, make sure that the required packages for Qt4 development of your
-distribution are installed, for Debian and Ubuntu these are:
+First, install the required packages by executing:
 
 ::
 
-    apt-get install qt4-qmake libqt4-dev build-essential libboost-dev libboost-system-dev \
-        libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev \
-        libssl-dev libdb4.8++-dev
+    sudo apt-get install qt4-qmake libqt4-dev build-essential libboost-dev libboost-system-dev \
+        libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev libssl-dev \
+        libdb5.3++-dev libminiupnpc-dev
 
 then execute the following:
 


### PR DESCRIPTION
In Linux build instructions, changed required packages. Changed libdb to version 5.3. Version 4.8 isn't available on Ubuntu 13.10/14.04. Added libminiupnpc-dev to get a needed header file.
